### PR TITLE
Look in built libs first

### DIFF
--- a/bi/build/Driver.cpp
+++ b/bi/build/Driver.cpp
@@ -24,6 +24,7 @@ using namespace boost::filesystem;
 bi::Driver::Driver(int argc, char** argv) :
     work_dir(current_path()),
     build_dir(current_path() / "build"),
+    lib_dir(current_path() / "build" / ".libs"),
     prefix(""),
     warnings(true),
     debug(true),
@@ -32,7 +33,8 @@ bi::Driver::Driver(int argc, char** argv) :
     newConfigure(false),
     newMake(false),
     newManifest(false),
-    isLocked(false) {
+    isLocked(false),
+    package() {
   enum {
     SHARE_DIR_ARG = 256,
     INCLUDE_DIR_ARG,
@@ -182,6 +184,11 @@ void bi::Driver::run(const std::string& prog) {
 #else
   so.replace_extension(".so");
 #endif
+
+  /* Look in built libs first. */
+  if(exists(lib_dir / so))
+    so = lib_dir / so;
+
   handle = dlopen(so.c_str(), RTLD_NOW);
   msg = dlerror();
   if (handle == NULL) {

--- a/bi/build/Driver.hpp
+++ b/bi/build/Driver.hpp
@@ -131,6 +131,11 @@ private:
   boost::filesystem::path build_dir;
 
   /**
+   * Built libraries directory.
+   */
+  boost::filesystem::path lib_dir;
+
+  /**
    * Share directories.
    */
   std::list<boost::filesystem::path> share_dirs;


### PR DESCRIPTION
Ensures that birch looks in the currently built library, if one exists.