### PR TITLE
Remove `GLOB_NOMAGIC` flag

### DIFF
--- a/driver/src/build/Driver.cpp
+++ b/driver/src/build/Driver.cpp
@@ -1249,7 +1249,10 @@ void birch::Driver::readFiles(const std::string& key) {
   for (auto pattern : metaContents[key]) {
     auto paths = glob(pattern);
     if (paths.empty()) {
-      warn("no file matching '" + pattern + "' in build configuration.");
+      /* print warning if pattern does not contain a wildcard '*' */
+      if (pattern.find('*') == std::string::npos) {
+        warn("no file matching '" + pattern + "' in build configuration.");
+      }
     } else {
       for (auto path : paths) {
         if (std::regex_search(path.string(), std::regex("\\s",

--- a/driver/src/build/Driver.cpp
+++ b/driver/src/build/Driver.cpp
@@ -1249,7 +1249,7 @@ void birch::Driver::readFiles(const std::string& key) {
   for (auto pattern : metaContents[key]) {
     auto paths = glob(pattern);
     if (paths.empty()) {
-        warn("no file matching '" + pattern + "' in build configuration.");
+      warn("no file matching '" + pattern + "' in build configuration.");
     } else {
       for (auto path : paths) {
         if (std::regex_search(path.string(), std::regex("\\s",

--- a/driver/src/build/Driver.hpp
+++ b/driver/src/build/Driver.hpp
@@ -122,9 +122,8 @@ private:
    * Consume a list of files from the build configuration file contents.
    *
    * @param key The key.
-   * @param checkExists Check if the files exists?
    */
-  void readFiles(const std::string& key, const bool checkExists);
+  void readFiles(const std::string& key);
 
   /**
    * Package name.

--- a/driver/src/build/misc.cpp
+++ b/driver/src/build/misc.cpp
@@ -36,9 +36,11 @@ fs::path birch::find(const std::list<fs::path>& paths, const fs::path& path) {
 std::list<fs::path> birch::glob(const std::string& pattern) {
   std::list<fs::path> results;
   glob_t matches;
-  glob(pattern.c_str(), GLOB_NOMAGIC, 0, &matches);
-  for (int i = 0; i < matches.gl_pathc; ++i) {
-    results.push_back(matches.gl_pathv[i]);
+  int rescode = glob(pattern.c_str(), 0, 0, &matches);
+  if (rescode == 0) {
+    for (int i = 0; i < matches.gl_pathc; ++i) {
+      results.push_back(matches.gl_pathv[i]);
+    }
   }
   globfree(&matches);
   return results;


### PR DESCRIPTION
This PR contains an extended version of one of the patches in https://github.com/JuliaPackaging/Yggdrasil/pull/1924.

The flag `GLOB_NOMAGIC` is removed which provides the following functionality according to the [libc docs](https://www.gnu.org/software/libc/manual/html_node/More-Flags-for-Globbing.html):

> If the pattern contains no wildcard constructs (it is a literal file name), return it as the sole “matching” word, even if no file exists by that name.

This flag is not supported by musl and hence currently Birch can't be built on such systems (and had to be patched for cross-compiling Birch with Yggdrasil on such host systems).

By removing the flag, every returned path is guaranteed to exist. Hence I modified the existing check (it is based on the number of returned paths instead of checking the existence of each path individually). The `checkExists` argument was always set to `true` in the current implementation, and therefore I removed it. If not desired, I can revert these modifications. 