### PR TITLE
Add FreeBSD support

### DIFF
--- a/driver/src/birch.hpp
+++ b/driver/src/birch.hpp
@@ -3,6 +3,11 @@
  */
 #pragma once
 
+#ifdef __FreeBSD__
+#define _WITH_GETLINE /* For getline */
+#include <sys/wait.h>  /* For WIF.. */
+#endif
+
 #include <vector>
 #include <stack>
 #include <list>

--- a/libraries/Standard/src/system/system.birch
+++ b/libraries/Standard/src/system/system.birch
@@ -1,3 +1,9 @@
+cpp{{
+#ifdef __FreeBSD__
+#include <sys/wait.h>  /* For WIF.. */
+#endif
+}}
+
 /**
  * Execute a command.
  *


### PR DESCRIPTION
This PR adds support for FreeBSD by applying the patches from https://github.com/JuliaPackaging/Yggdrasil/pull/1924.

However, currently CI tests do not run on FreeBSD so this PR is not tested (and only the linked PR indicates that it is working properly). It seems OBS and CircleCI do not support FreeBSD (at least not in a trivial way). Maybe CirrusCI could be used?