### PR TITLE
Fix FreeBSD support and add Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ env:
   PREFIX: ${CIRRUS_WORKING_DIR}/project
   PATH: ${PREFIX}/bin:${PATH}
   BIRCH_FLAGS: '--unit=dir --arch=native --jobs=2'
-  MODE_FLAGS: '--disable-debug --enable-test --enable-release'
+  MODE_FLAGS: '--enable-debug --disable-test --disable-release'
   OMP_NUM_THREADS: 2
 
 task:
@@ -41,7 +41,7 @@ task:
     - birch install
   birch-standard_smoke_script:
     - cd libraries/Standard
-    - env BIRCH_MODE=test bash ./smoke.sh
+    - env BIRCH_MODE=debug bash ./smoke.sh
   birch-cairo_build_script:
     - cd libraries/Cairo
     - birch build --prefix="${PREFIX}" ${MODE_FLAGS} ${BIRCH_FLAGS}
@@ -73,7 +73,7 @@ example_task_template: &EXAMPLE_TASK_TEMPLATE
     - birch install
   smoke_script:
     - cd "examples/${EXAMPLE}"
-    - env BIRCH_MODE=test bash ./smoke.sh
+    - env BIRCH_MODE=debug bash ./smoke.sh
 
 task:
   name: FreeBSD LinearGaussian

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,119 @@
+env:
+  CPPFLAGS: -I/usr/local/include
+  LDFLAGS: -L/usr/local/lib
+  PREFIX: ${CIRRUS_WORKING_DIR}/project
+  PATH: ${PREFIX}/bin:${PATH}
+  BIRCH_FLAGS: '--unit=dir --arch=native --jobs=2'
+  MODE_FLAGS: '--disable-debug --enable-test --enable-release'
+  OMP_NUM_THREADS: 2
+
+task:
+  name: FreeBSD
+  freebsd_instance:
+    image_family: freebsd-12-1
+    cpu: 2
+    memory: 4G
+  install_script:
+    - pkg install -y automake bash bison boost-libs cairo eigen libtool libyaml sqlite3
+  driver_build_script:
+    - cd driver
+    - ./bootstrap
+    - ./configure --prefix="${PREFIX}" CXXFLAGS="-Wall -Wno-overloaded-virtual -g -O0 -fno-inline --coverage" || cat config.log
+    - make -j4
+    - make install
+  driver_test_script:
+    - mkdir hello
+    - cd hello
+    - birch help
+    - birch init
+    - birch audit
+    - birch dist
+    - birch clean
+  libbirch_build_script:
+    - cd libbirch
+    - ./bootstrap
+    - ./configure --prefix="${PREFIX}" ${MODE_FLAGS} || cat config.log
+    - make -j4
+    - make install
+  birch-standard_build_script:
+    - cd libraries/Standard
+    - birch build --prefix="${PREFIX}" ${MODE_FLAGS} ${BIRCH_FLAGS}
+    - birch install
+  birch-standard_smoke_script:
+    - cd libraries/Standard
+    - env BIRCH_MODE=test bash ./smoke.sh
+  birch-cairo_build_script:
+    - cd libraries/Cairo
+    - birch build --prefix="${PREFIX}" ${MODE_FLAGS} ${BIRCH_FLAGS}
+    - birch install
+  birch-sqlite_build_script:
+    - cd libraries/SQLite
+    - birch build --prefix="${PREFIX}" ${MODE_FLAGS} ${BIRCH_FLAGS}
+    - birch install
+  upload_cache_script:
+    - tar -czvf cache.tar.gz -C "$PREFIX" .
+    - curl -s -X POST --data-binary @cache.tar.gz http://${CIRRUS_HTTP_CACHE_HOST}/birch-${CIRRUS_OS}-${CIRRUS_CHANGE_IN_REPO}
+
+# https://cirrus-ci.org/guide/tips-and-tricks/#sharing-configuration-between-tasks
+example_task_template: &EXAMPLE_TASK_TEMPLATE
+  depends_on: FreeBSD
+  freebsd_instance:
+    image_family: freebsd-12-1
+    cpu: 1
+    memory: 2G
+  download_cache_script:
+    - curl http://${CIRRUS_HTTP_CACHE_HOST}/birch-${CIRRUS_OS}-${CIRRUS_CHANGE_IN_REPO} -o cache.tar.gz
+    - mkdir -p "${PREFIX}"
+    - tar -xzvf cache.tar.gz -C "${PREFIX}"
+  install_script:
+    - pkg install -y automake bash bison boost-libs eigen libtool libyaml ${PACKAGES}
+  build_script:
+    - cd "examples/${EXAMPLE}"
+    - birch build --prefix="${PREFIX}" ${MODE_FLAGS} ${BIRCH_FLAGS} || cat config.log
+    - birch install
+  smoke_script:
+    - cd "examples/${EXAMPLE}"
+    - env BIRCH_MODE=test bash ./smoke.sh
+
+task:
+  name: FreeBSD LinearGaussian
+  env:
+    EXAMPLE: LinearGaussian
+  << : *EXAMPLE_TASK_TEMPLATE
+
+task:
+  name: FreeBSD LinearRegression
+  env:
+    EXAMPLE: LinearRegression
+  << : *EXAMPLE_TASK_TEMPLATE
+
+task:
+  name: FreeBSD MixedGaussian
+  env:
+    EXAMPLE: MixedGaussian
+  << : *EXAMPLE_TASK_TEMPLATE
+
+task:
+  name: FreeBSD MultiObjectTracking
+  env:
+    EXAMPLE: MultiObjectTracking
+    PACKAGES: cairo
+  << : *EXAMPLE_TASK_TEMPLATE
+
+task:
+  name: FreeBSD PoissonGaussian
+  env:
+    EXAMPLE: PoissonGaussian
+  << : *EXAMPLE_TASK_TEMPLATE
+
+task:
+  name: FreeBSD SIR
+  env:
+    EXAMPLE: SIR
+  << : *EXAMPLE_TASK_TEMPLATE
+
+task:
+  name: FreeBSD VectorBorneDisease
+  env:
+    EXAMPLE: VectorBorneDisease
+  << : *EXAMPLE_TASK_TEMPLATE

--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -1,0 +1,48 @@
+name: Slack message
+
+on:
+  check_suite:
+    types: ['completed']
+
+jobs:
+  message:
+    name: After check suite failure
+    if: github.event.check_suite.conclusion != 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # Documentation: https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#get-a-check-suite
+      - name: Obtain failed check run
+        uses: octokit/request-action@v2.x
+        id: get_failed_check_run
+        with:
+          route: GET /repos/${{ github.repository }}/check-suites/${{ github.event.check_suite.id }}/check-runs?status=completed
+          mediaType: '{"previews": ["antiope"]}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Documentation: https://api.slack.com/methods/chat.postMessage
+      - name: Post message in Slack channel
+        run: |
+          curl -X POST -H 'Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}' -H 'Content-type: application/json' --data '${{ env.DATA }}' https://slack.com/api/chat.postMessage
+        env:
+          DATA: '{
+                    "channel": "${{ secrets.SLACK_CHANNEL }}",
+                    "attachments": [{
+                        "fallback": ":red_circle: Check run ${{ fromJson(steps.get_failed_check_run.outputs.data).check_runs[0].name }} has failed!\n<${{ fromJson(steps.get_failed_check_run.outputs.data).check_runs[0].html_url }}|Visit run>",
+                        "pretext": ":red_circle: Check run ${{ fromJson(steps.get_failed_check_run.outputs.data).check_runs[0].name }} has failed!",
+                        "color": "#FF0000",
+                        "title": "Visit run",
+                        "title_link": "${{ fromJson(steps.get_failed_check_run.outputs.data).check_runs[0].html_url }}",
+                        "fields": [
+                            {
+                                "title": "Repository",
+                                "value": "${{ github.repository }}",
+                                "short": true
+                            },
+                            {
+                                "title": "Run",
+                                "value": "${{ fromJson(steps.get_failed_check_run.outputs.data).check_runs[0].id }}",
+                                "short": true
+                            }
+                        ]
+                    }]
+                 }'

--- a/driver/src/build/Driver.cpp
+++ b/driver/src/build/Driver.cpp
@@ -496,7 +496,7 @@ void birch::Driver::dist() {
 
   /* archiving command */
   std::stringstream cmd;
-  #ifdef __APPLE__
+  #if defined(__APPLE__) || defined(__FreeBSD__)
   /* BSD tar */
   cmd << "tar -s '#^#" << archive << "/#' -czf " << archive << ".tar.gz";
   #else


### PR DESCRIPTION
Hej!

I noticed that one additional tiny change is needed to not only compile but also use Birch on FreeBSD (BSD tar instead GNU tar).

I added CI tests on [Cirrus](https://cirrus-ci.org/) to ensure that the libraries and examples work on FreeBSD. All tests passed: https://cirrus-ci.com/build/4576798367285248 If you want to keep them you would have to add the [Cirrus CI app](https://cirrus-ci.org/guide/quick-start/) (it's free for public repos). It seems the Cirrus tests are quite slow compared with Circle CI (partly but not only due to the package installations), and hence I enabled only smoke tests but no unit tests.