### PR TITLE
Restrict Slack notifications

### DIFF
--- a/.github/workflows/slack.yml
+++ b/.github/workflows/slack.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   message:
     name: After check suite failure
-    if: github.event.check_suite.conclusion != 'success'
+    if: github.event.check_suite.app.name == 'Cirrus CI' && github.event.check_suite.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:
       # Documentation: https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#get-a-check-suite


### PR DESCRIPTION
With this PR Slack messages are only posted when Cirrus checks fail with status 'failure'. Currently notifications are sent whenever the status of any completed check suite is not 'success'. This includes also Circle CI tests and tests that are skipped.