### PR TITLE
Ensure that copied files are writeable

### DIFF
--- a/driver/src/build/misc.cpp
+++ b/driver/src/build/misc.cpp
@@ -46,6 +46,13 @@ std::list<fs::path> birch::glob(const std::string& pattern) {
   return results;
 }
 
+void birch::copy_file_writeable(fs::path src, fs::path dst) {
+  using namespace fs;
+
+  copy_file(src, dst);
+  permissions(dst, perms::add_perms | perms::owner_write);
+}
+
 bool birch::copy_if_newer(fs::path src, fs::path dst) {
   using namespace fs;
 
@@ -53,11 +60,11 @@ bool birch::copy_if_newer(fs::path src, fs::path dst) {
    * workaround... */
   bool result = false;
   if (!exists(dst)) {
-    copy_file(src, dst);
+    copy_file_writeable(src, dst);
     result = true;
   } else if (last_write_time(src) > last_write_time(dst)) {
     remove(dst);
-    copy_file(src, dst);
+    copy_file_writeable(src, dst);
     result = true;
   }
   return result;
@@ -74,24 +81,22 @@ bool birch::copy_with_prompt(fs::path src, fs::path dst) {
     std::getline(std::cin, ans);
     if (ans.length() > 0 && (ans[0] == 'y' || ans[0] == 'Y')) {
       remove(dst);
-      copy_file(src, dst);
+      copy_file_writeable(src, dst);
       result = true;
     }
   } else {
-    copy_file(src, dst);
+    copy_file_writeable(src, dst);
     result = true;
   }
   return result;
 }
 
 void birch::copy_with_force(fs::path src, fs::path dst) {
-  using namespace fs;
-
-  if (exists(dst)) {
-    remove(dst);
-    copy_file(src, dst);
+  if (fs::exists(dst)) {
+    fs::remove(dst);
+    copy_file_writeable(src, dst);
   } else {
-    copy_file(src, dst);
+    copy_file_writeable(src, dst);
   }
 }
 

--- a/driver/src/build/misc.hpp
+++ b/driver/src/build/misc.hpp
@@ -33,6 +33,15 @@ fs::path find(const std::list<fs::path>& paths, const fs::path& path);
 std::list<fs::path> glob(const std::string& pattern);
 
 /**
+ * Copy a source file to a destination file, and ensure that the
+ * destination file is writeable.
+ *
+ * @param src Source file.
+ * @param dst Destination file.
+ */
+void copy_file_writeable(fs::path src, fs::path dst);
+
+/**
  * Copy a source file to a destination file, but only if the destination
  * file does not exist, or the source file is newer.
  *


### PR DESCRIPTION
I tried to run the HelloWorld example from within Julia, using the Birch_jll package, and noticed that `birch init --package HelloWorld` fails (https://github.com/JuliaPackaging/Yggdrasil/issues/1969#issuecomment-737306907). The problem is that the Julia package manager enforces the immutability of the installed binaries by making all files read-only (https://github.com/JuliaLang/Pkg.jl/blob/cce236e1866f6fe2653a4e202bc6eca47f8ddd7a/src/Artifacts.jl#L60), and these read-only file permissions are then propagated to the files that are copied to the user directory. When Birch tries to modify `birch.yml` this leads to an error.

It was suggested in the linked issue to copy the files manually in Julia but I was not satisfied with this solution since it seems weird to reimplement an existing feature of Birch and it would have to be updated whenever `birch init` or the distributed files are changed. Instead I thought it would be easier to handle this issue in Birch and ensure that the copied files are writeable by the user. If you do not want to include this functionality in Birch, I could just add it as a patch to the Julia build script.

I checked the PR locally by manually modifying the permissions of the installed files in the `${PREFIX}/share/birch/` directory and running `birch init --package HelloWorld`. It was not clear to me if such a test should be included in CircleCI or Cirrus to avoid any regressions.