### PR TITLE
Fix write bug for Expression class

### DIFF
--- a/libraries/Standard/src/distribution/Gaussian.birch
+++ b/libraries/Standard/src/distribution/Gaussian.birch
@@ -109,8 +109,8 @@ class Gaussian(μ:Expression<Real>, σ2:Expression<Real>) <
   function write(buffer:Buffer) {
     prune();
     buffer.set("class", "Gaussian");
-    buffer.set("μ", μ.value());
-    buffer.set("σ2", σ2.value());
+    buffer.set("μ", μ);
+    buffer.set("σ2", σ2);
   }
 }
 

--- a/libraries/Standard/src/distribution/Poisson.birch
+++ b/libraries/Standard/src/distribution/Poisson.birch
@@ -66,7 +66,7 @@ class Poisson(λ:Expression<Real>) < Discrete {
   function write(buffer:Buffer) {
     prune();
     buffer.set("class", "Poisson");
-    buffer.set("λ", λ.value());
+    buffer.set("λ", λ);
   }
 }
 

--- a/libraries/Standard/src/expression/Expression.birch
+++ b/libraries/Standard/src/expression/Expression.birch
@@ -713,4 +713,8 @@ abstract class Expression<Value>(x:Value?) < DelayExpression(x?) {
   function graftBoundedDiscrete() -> BoundedDiscrete? {
     return nil;
   }
+
+  override function write(buffer:Buffer) {
+    buffer.set(value());
+  }
 }


### PR DESCRIPTION
The `write(buffer:Buffer)` function is overwritten in the Expression class, so there is no need to call `value()` in the distribution classes. Also, removed `value()` calls in the `write(buffer:Buffer)` functions of Poisson and Gaussian distribution classes.