### PR TITLE
Upgrade Cirrus to FreeBSD 12.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ env:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-12-2
+    image_family: freebsd-12-3
     cpu: 8
     memory: 16G
   install_script:
@@ -51,7 +51,7 @@ task:
 example_task_template: &EXAMPLE_TASK_TEMPLATE
   depends_on: FreeBSD
   freebsd_instance:
-    image_family: freebsd-12-2
+    image_family: freebsd-12-3
     cpu: 4
     memory: 8G
   download_cache_script:


### PR DESCRIPTION
I noticed that the FreeBSD tests failed in #18. I googled the error message and came across https://github.com/tpm2-software/tpm2-abrmd/issues/808, so maybe upgrading to FreeBSD 12.3 fixes the issue.