### PR TITLE
Fix `git clone` instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ improvements, and will be linked in automatically if found:
 
 All Birch sources are in the same repository. Clone it:
 
-    git clone -b stable https://github.com/lawmurray/Birch.git
+    git clone https://github.com/lawmurray/Birch.git
 
 and change to the `Birch` directory:
 


### PR DESCRIPTION
Fixes #24.