### PR TITLE
Run tests on FreeBSD 14.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ env:
 task:
   name: FreeBSD
   freebsd_instance:
-    image_family: freebsd-12-3
+    image_family: freebsd-14-2
     cpu: 8
     memory: 16G
   install_script:


### PR DESCRIPTION
Freebsd 12.3 is not available anymore on Cirrus (and very outdated by now): https://github.com/lawmurray/Birch/pull/25/checks?check_run_id=34581420947